### PR TITLE
Downtime events can have one to many service requests

### DIFF
--- a/src/main/java/cumulocity/microservice/service/request/mgmt/controller/ServiceRequestController.java
+++ b/src/main/java/cumulocity/microservice/service/request/mgmt/controller/ServiceRequestController.java
@@ -248,7 +248,7 @@ public class ServiceRequestController {
 	@PutMapping(path = "/{serviceRequestId}/event", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<ServiceRequest> addEventRefToServiceRequest(@PathVariable String serviceRequestId,
 			@Valid @RequestBody ServiceRequestDataRef eventRef) {
-		ServiceRequestValidationResult validateEvent = serviceRequestService.validateEvent(eventRef, null);
+		ServiceRequestValidationResult validateEvent = serviceRequestService.validateEvent(serviceRequestId,eventRef, null);
 		if(ServiceRequestValidationResult.EVENT_NOT_FOUND.equals(validateEvent)) {
 			log.warn(validateEvent.getMessage());
 			return new ResponseEntity<ServiceRequest>(HttpStatus.PRECONDITION_FAILED);

--- a/src/main/java/cumulocity/microservice/service/request/mgmt/service/ServiceRequestService.java
+++ b/src/main/java/cumulocity/microservice/service/request/mgmt/service/ServiceRequestService.java
@@ -21,7 +21,7 @@ public interface ServiceRequestService {
 
 	public ServiceRequestValidationResult validateAlarm(ServiceRequestDataRef serviceRequestDataRef, String alarmJsonString);
 
-	public ServiceRequestValidationResult validateEvent(ServiceRequestDataRef serviceRequestDataRef, String eventJsonString);
+	public ServiceRequestValidationResult validateEvent(String serviceRequestId, ServiceRequestDataRef serviceRequestDataRef, String eventJsonString);
 
 	public ServiceRequest createServiceRequest(ServiceRequestPostRqBody serviceRequest, String owner);
 	

--- a/src/main/java/cumulocity/microservice/service/request/mgmt/service/c8y/EventMapper.java
+++ b/src/main/java/cumulocity/microservice/service/request/mgmt/service/c8y/EventMapper.java
@@ -6,7 +6,7 @@ import com.cumulocity.rest.representation.event.EventRepresentation;
 import cumulocity.microservice.service.request.mgmt.model.ServiceRequestDataRef;
 
 public class EventMapper {
-	public static final String SR_EVENT_ID = "sr_EventId";
+	public static final String SR_EVENT_ID = "sr_EventId!";
 
 	private EventRepresentation event;
 	
@@ -26,15 +26,15 @@ public class EventMapper {
 		this.event.setId(GId.asGId(eventId));
 	}
 	
-	public String getServiceRequestEventId() {
-		return (String) event.get(SR_EVENT_ID);
-	}
+	// public String getServiceRequestEventId() {
+	// 	return (String) event.get(SR_EVENT_ID);
+	// }
 	
 	public void setServiceRequestEventId(String serviceRequestEventId) {
 		if(serviceRequestEventId == null) {
 			return;
 		}
-		event.set(serviceRequestEventId, SR_EVENT_ID);
+		event.set(new Object(), SR_EVENT_ID+serviceRequestEventId);
 	}
 
 	public EventRepresentation getEvent() {

--- a/src/main/java/cumulocity/microservice/service/request/mgmt/service/c8y/EventMapper.java
+++ b/src/main/java/cumulocity/microservice/service/request/mgmt/service/c8y/EventMapper.java
@@ -25,11 +25,7 @@ public class EventMapper {
 		this.event = new EventRepresentation();
 		this.event.setId(GId.asGId(eventId));
 	}
-	
-	// public String getServiceRequestEventId() {
-	// 	return (String) event.get(SR_EVENT_ID);
-	// }
-	
+
 	public void setServiceRequestEventId(String serviceRequestEventId) {
 		if(serviceRequestEventId == null) {
 			return;

--- a/src/main/java/cumulocity/microservice/service/request/mgmt/service/c8y/ServiceRequestServiceC8y.java
+++ b/src/main/java/cumulocity/microservice/service/request/mgmt/service/c8y/ServiceRequestServiceC8y.java
@@ -143,7 +143,7 @@ public class ServiceRequestServiceC8y implements ServiceRequestService {
 				// Decision to use no reference for downtime service requests!
 				return ServiceRequestValidationResult.VALID;
 			case NOTE:
-				return validateEvent(serviceRequestRqBody.getEventRef(), serviceRequestRqBody.getEvent());
+				return validateEvent(null, serviceRequestRqBody.getEventRef(), serviceRequestRqBody.getEvent());
 			case OTHER:
 				return ServiceRequestValidationResult.VALID;
 			default:
@@ -199,7 +199,7 @@ public class ServiceRequestServiceC8y implements ServiceRequestService {
 	}
 
 	@Override
-	public ServiceRequestValidationResult validateEvent(ServiceRequestDataRef eventRef, String eventJsonString) {
+	public ServiceRequestValidationResult validateEvent(String serviceRequestId, ServiceRequestDataRef eventRef, String eventJsonString) {
 		if (eventRef == null && eventJsonString == null) {
 			return ServiceRequestValidationResult.MISSING_EVENT_REF;
 		}
@@ -222,10 +222,15 @@ public class ServiceRequestServiceC8y implements ServiceRequestService {
 		if(event == null) {
 			return ServiceRequestValidationResult.EVENT_NOT_FOUND;
 		}
-		Object srId = event.get(EventMapper.SR_EVENT_ID);
-		if (srId != null) {
-			return ServiceRequestValidationResult.EVENT_ASSIGNED;
+
+		if(serviceRequestId != null) {
+			// Check if the event already has a service request ID associated with it.
+			// If `srId` is not null and not equal to the current service request ID, it means the event is already assigned to another service request.
+			Object srId = event.get(EventMapper.SR_EVENT_ID + serviceRequestId);
+			if (srId != null) {
+				return ServiceRequestValidationResult.EVENT_ASSIGNED;
 			
+			}
 		}
 		return ServiceRequestValidationResult.VALID;
 	}


### PR DESCRIPTION
Downtime events can have a list of related service requests. This means that on related event need "n" sr_EventIds as reference. 

Example:

```json
{
  "creationTime": "2026-02-06T11:33:03.101Z",
  "id": "382134607",
  "isGroup": {},
  "lastUpdated": "2026-02-06T11:33:04.136Z",
  "reminderType": "downtime.end",
  "self": "https://t8800.iot-dev.enercon.de/event/events/382134607",
  "source": {
    "id": "14104075546",
    "self": "https://t8800.iot-dev.enercon.de/inventory/managedObjects/14104075546"
  },
  "sr_EventId!382134604": {},
  "sr_EventId!382136301": {},
  "status": "ACTIVE",
  "text": "Downtime notification",
  "time": "2026-04-01T17:45:00.000Z",
  "type": "c8y_Reminder"
}
```